### PR TITLE
minimize number of RUN statements for less layers in the resulting image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,39 @@ FROM debian:9.4
 
 MAINTAINER Me "me@me.com"
 
-# Update package list
-RUN dpkg --add-architecture amd64
-RUN apt-get update
+# Add amd64 architecture, update package list & install needed packages
+RUN dpkg --add-architecture amd64 \
+    && apt-get update \
+    && apt-get -y install \
+    openssh-server \
+    gcc \
+    g++ \
+    make \
+    autoconf \
+    automake \
+    git-core \
+    libreadline-dev \
+    bison \
+    flex \
+    zlib1g-dev \
+    libxml2-dev \
+    libxml2-utils \
+    docbook 
 
 # Set locale (fix locale warnings)
 RUN localedef -v -c -i en_US -f UTF-8 en_US.UTF-8 || :
-RUN echo "America/Los_Angeles" > /etc/timezone
-RUN dpkg-reconfigure -f noninteractive tzdata
-
-# Install ssh too in case we need to ssh into the instance
-RUN apt-get -y install openssh-server
-
-# Install more compiler tools, and PostgreSQL deps
-RUN apt-get -y install gcc g++ make autoconf automake git-core libreadline-dev bison flex zlib1g-dev libxml2-dev libxml2-utils docbook
+RUN echo "America/Los_Angeles" > /etc/timezone \
+    && dpkg-reconfigure -f noninteractive tzdata
 
 # Add the new user called postgres
 RUN useradd -ms /bin/bash postgres
 
-RUN mkdir /var/log/postgresql /var/lib/postgresql /usr/local/pgsql
-
-RUN chown -R postgres:postgres /var/log/postgresql /var/lib/postgresql /usr/local/pgsql
+RUN mkdir /var/log/postgresql \
+    /var/lib/postgresql \
+    /usr/local/pgsql \
+    && chown -R postgres:postgres /var/log/postgresql \
+    /var/lib/postgresql \
+    /usr/local/pgsql
 
 # Clone the PostgreSQL upstream Git repository
 RUN cd /root ; git clone https://github.com/postgres/postgres


### PR DESCRIPTION
Minimizing the number of RUN statements results in lower number of layers in the resulting image but also conforms to docker best practices around package managers.
Running apt-get update in different statements from apt-get install might result in unwanted behaviour.